### PR TITLE
Added Fedora-based install script.

### DIFF
--- a/fedora-based-install.sh
+++ b/fedora-based-install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+BGreen='\033[1;32m'
+clean='\033[0m'
+pkgname=kde-material-you-colors
+
+echo -e "${BGreen}Installing dependencies${clean}"
+sudo dnf update
+sudo dnf install python3 python3-dbus python3-numpy
+
+echo -e "${BGreen}Installing kde-material-you-colors${clean}"
+mkdir -p /usr/lib/${pkgname}
+cp -f *.{py,conf,desktop} /usr/lib/${pkgname}/
+cp -f kde-material-you-colors /usr/bin/kde-material-you-colors
+cp -f material-color-utility-bin /usr/lib/${pkgname}/material-color-utility-bin
+cp -f libSkiaSharp.so /usr/lib/${pkgname}/libSkiaSharp.so
+chmod 755 /usr/lib/${pkgname}/*.py
+
+mkdir -p /usr/share/licenses/kde-material-you-colors/
+cp -f LICENSE /usr/share/licenses/${pkgname}/LICENSE
+chmod 664 /usr/share/licenses/${pkgname}/LICENSE
+chmod 664 /usr/lib/${pkgname}/*.{desktop,conf}
+
+chmod 755 /usr/bin/kde-material-you-colors
+chmod 755 /usr/lib/${pkgname}/material-color-utility-bin
+chmod 755 /usr/lib/${pkgname}/libSkiaSharp.so
+ln -sf /usr/lib/${pkgname}/material-color-utility-bin /usr/bin/material-color-utility

--- a/fedora-based-install.sh
+++ b/fedora-based-install.sh
@@ -3,9 +3,14 @@ BGreen='\033[1;32m'
 clean='\033[0m'
 pkgname=kde-material-you-colors
 
+if ! [ $(id -u) = 0 ]; then
+    echo "This script must be run as sudo or root, try again..."
+    exit 1
+fi;
+
 echo -e "${BGreen}Installing dependencies${clean}"
-sudo dnf update
-sudo dnf install python3 python3-dbus python3-numpy
+dnf update
+dnf install python3 python3-dbus python3-numpy
 
 echo -e "${BGreen}Installing kde-material-you-colors${clean}"
 mkdir -p /usr/lib/${pkgname}


### PR DESCRIPTION
Modified the existing Ubuntu install script to use Fedora's package manager. Also added a sudo check in front of the script, as none of the script needs to run if not running as sudo. This can probably be copied into the Ubuntu installer, but I'm running Fedora at the moment and cannot test it with Ubuntu.