### PR TITLE
.NET: Update MaterialColorUtilities to v0.1.1

### DIFF
--- a/material-color-utility/Program.cs
+++ b/material-color-utility/Program.cs
@@ -127,6 +127,7 @@ class Program
             Scheme<int> darkScheme = new DarkSchemeMapper().Map(corePalette);
             lightScheme.Primary = corePalette.Primary[40];
             darkScheme.Primary = corePalette.Primary[70];
+            darkScheme.Error = corePalette.Error[70];
             //TODO: Save color palette to single json
             // var colors = new Dictionary<string, string>();
 

--- a/material-color-utility/material-color-utility.csproj
+++ b/material-color-utility/material-color-utility.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialColorUtilities" Version="0.1.0" />
+    <PackageReference Include="MaterialColorUtilities" Version="0.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SkiaSharp" Version="2.80.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.80.3" />


### PR DESCRIPTION
* also make Error color for darkScheme a bit darker