### PR TITLE
utils: Add support for Klassy TitleBar opacity control

### DIFF
--- a/src/kde-material-you-colors
+++ b/src/kde-material-you-colors
@@ -47,9 +47,9 @@ if __name__ == '__main__':
                         help='Tint Sierra Breeze decoration buttons')
     parser.add_argument('--konsole-profile', '-kp', type=str,
                         help='The name of your (existing) Konsole profile that is going to be themed, you can check your current profiles with konsole  --list-profiles', default=None)
-    parser.add_argument('--sbe-titlebar-opacity', '-sbeto', type=int,
-                        help='Sierra Breeze Enhanced titlebar opacity (value from 0 to 100, default is None)', default=None)
-    parser.add_argument('--toolbar-opacity', '-to', type=int,
+    parser.add_argument('--titlebar-opacity', '-tio', type=int,
+                        help='Titlebar opacity (value from 0 to 100, default is None)', default=None)
+    parser.add_argument('--toolbar-opacity', '-too', type=int,
                         help='ToolBar opacity, needs Lightly Application Style (value from 0 to 100, default is None)', default=None)
     parser.add_argument('--konsole-opacity', '-ko', type=int,
                         help='Konsole background opacity (value from 0 to 100, default is None)', default=None)
@@ -98,7 +98,7 @@ if __name__ == '__main__':
                         light=light)
             if options_old['sierra_breeze_buttons_color'] == True:
                 utils.sierra_breeze_button_colors(schemes,light)
-            utils.sierra_breeze_enhanced_titlebar_opacity(options_old['sbe_titlebar_opacity'])
+            utils.titlebar_opacity(options_old['titlebar_opacity'])
             utils.set_icons(icons_light=options_old['iconslight'],
                 icons_dark=options_old['iconsdark'], light=options_old['light'])
             utils.make_konsole_mirror_profile(konsole_profile_old)
@@ -169,7 +169,7 @@ if __name__ == '__main__':
                     utils.apply_color_schemes(light=light)
                     if options_new['sierra_breeze_buttons_color'] == True:
                         utils.sierra_breeze_button_colors(schemes,light)
-                    utils.sierra_breeze_enhanced_titlebar_opacity(options_new['sbe_titlebar_opacity'])
+                    utils.titlebar_opacity(options_new['titlebar_opacity'])
                     utils.konsole_apply_color_scheme(light,options_new['pywal_light'],schemes,options_new['konsole_profile'], konsole_opacity=options_new['konsole_opacity'])
                     utils.apply_pywal_schemes(
                         light=light, use_pywal=options_new['pywal'], pywal_light=options_new['pywal_light'], schemes=schemes)

--- a/src/sample_config.conf
+++ b/src/sample_config.conf
@@ -92,18 +92,20 @@ ncolor = 0
 # Konsole background opacity 
 # An integer between 0 and 100
 # Default is commented (disabled)
-#konsole_opacity = 75
+#konsole_opacity = 85
 
-# Sierra Breeze Enhanced Title Bar opacity https://github.com/kupiqu/SierraBreezeEnhanced
+# Title Bar opacity
+# Requires one of the following window decorations:
+# Klassy https://github.com/paulmcauley/klassy || Sierra Breeze Enhanced https://github.com/kupiqu/SierraBreezeEnhanced
 # An integer between 0 and 100
 # Default is commented (disabled)
 # NOTE:
 # This will reload KWin (screen will blink on x11)
-#sbe_titlebar_opacity = 50
+#titlebar_opacity = 85
 
 # ToolBar opacity needs Lightly Application Style to work https://github.com/Luwx/Lightly
 # An integer between 0 and 100
 # Default is commented (disabled)
 # NOTE:
 # kirigami ToolBar opacity is not affected by this option https://github.com/Luwx/Lightly/issues/128
-#toolbar_opacity = 75
+#toolbar_opacity = 85

--- a/src/utils.py
+++ b/src/utils.py
@@ -40,6 +40,7 @@ PICTURE_OF_DAY_BING_PROVIDER = 'bing'
 KDE_GLOBALS = HOME+"/.config/kdeglobals"
 BREEZE_RC = HOME+"/.config/breezerc"
 SBE_RC = HOME+"/.config/sierrabreezeenhancedrc"
+KLASSY_RC = HOME+"/.config/klassyrc"
 KONSOLE_DIR = HOME+"/.local/share/konsole/"
 KONSOLE_COLOR_SCHEME_PATH = KONSOLE_DIR+"MaterialYou.colorscheme"
 KONSOLE_COLOR_SCHEME_ALT_PATH = KONSOLE_DIR+"MaterialYouAlt.colorscheme"
@@ -125,7 +126,7 @@ class Configs():
         dict: Settings dictionary
     """
     def __init__(self, args):
-        c_light = c_monitor = c_file = c_plugin = c_ncolor = c_iconsdark = c_iconslight = c_pywal = c_pywal_light = c_light_blend_multiplier = c_dark_blend_multiplier = c_on_change_hook = c_sierra_breeze_buttons_color = c_konsole_profile = c_sbe_titlebar_opacity = c_toolbar_opacity = c_konsole_opacity = None
+        c_light = c_monitor = c_file = c_plugin = c_ncolor = c_iconsdark = c_iconslight = c_pywal = c_pywal_light = c_light_blend_multiplier = c_dark_blend_multiplier = c_on_change_hook = c_sierra_breeze_buttons_color = c_konsole_profile = c_titlebar_opacity = c_toolbar_opacity = c_konsole_opacity = None
         # User may just want to set the startup script / default config, do that only and exit
         if args.autostart == True:
             if not os.path.exists(USER_AUTOSTART_SCRIPT_PATH):
@@ -217,11 +218,11 @@ class Configs():
                         if 'konsole_profile' in custom:
                             c_konsole_profile = custom['konsole_profile']
                             
-                        if 'sbe_titlebar_opacity' in custom:
-                            c_sbe_titlebar_opacity = custom.getint('sbe_titlebar_opacity')
-                            if c_sbe_titlebar_opacity < 0 or c_sbe_titlebar_opacity > 100:
+                        if 'titlebar_opacity' in custom:
+                            c_titlebar_opacity = custom.getint('titlebar_opacity')
+                            if c_titlebar_opacity < 0 or c_titlebar_opacity > 100:
                                 raise ValueError(
-                                    'Value for sbe_titlebar_opacity must be an integer betwritten 0 and 100, using default 100')
+                                    'Value for titlebar_opacity must be an integer betwritten 0 and 100, using default 100')
                         
                         if 'toolbar_opacity' in custom:
                             c_toolbar_opacity = custom.getint('toolbar_opacity')
@@ -315,14 +316,14 @@ class Configs():
             elif c_konsole_profile == None:
                 c_konsole_profile = args.konsole_profile
                 
-            if args.sbe_titlebar_opacity != None:
-                if args.sbe_titlebar_opacity < 0 or args.sbe_titlebar_opacity > 100:
+            if args.titlebar_opacity != None:
+                if args.titlebar_opacity < 0 or args.titlebar_opacity > 100:
                     logging.error('Value for --sbe-titlebar-opacity must be an integer betwritten 0 and 100')
                     raise ValueError
                 else:
-                    c_sbe_titlebar_opacity = args.sbe_titlebar_opacity
-            elif args.sbe_titlebar_opacity == None and c_sbe_titlebar_opacity == None:
-                c_sbe_titlebar_opacity = None
+                    c_titlebar_opacity = args.titlebar_opacity
+            elif args.titlebar_opacity == None and c_titlebar_opacity == None:
+                c_titlebar_opacity = None
                 
             if args.toolbar_opacity != None:
                 if args.toolbar_opacity < 0 or args.toolbar_opacity > 100:
@@ -357,7 +358,7 @@ class Configs():
                 "on_change_hook": c_on_change_hook,
                 "sierra_breeze_buttons_color" : c_sierra_breeze_buttons_color,
                 "konsole_profile" : c_konsole_profile,
-                "sbe_titlebar_opacity" : c_sbe_titlebar_opacity,
+                "sbe_titlebar_opacity" : c_titlebar_opacity,
                 "toolbar_opacity" : c_toolbar_opacity,
                 "konsole_opacity" : c_konsole_opacity
                 }
@@ -1062,27 +1063,45 @@ def kwin_blend_changes():
         logging.warning(f'Could not start blend effect (requires Plasma 5.25 or later):\n{e}')
         return None
 
-def sierra_breeze_enhanced_titlebar_opacity(opacity):
+def titlebar_opacity(opacity):
     if opacity != None:
         opacity = range_check(opacity,0,100)
-        sberc = configparser.ConfigParser()
+        conf_file = configparser.ConfigParser()
         # preserve case
-        sberc.optionxform = str
+        conf_file.optionxform = str
+        
         if os.path.exists(SBE_RC):
             try:
-                sberc.read(SBE_RC)
-                if 'Windeco' in sberc:
-                    sberc['Windeco']['BackgroundOpacity'] = str(int(opacity))
+                conf_file.read(SBE_RC)
+                if 'Windeco' in conf_file:
+                    conf_file['Windeco']['BackgroundOpacity'] = str(int(opacity))
                     reload = True
                 else:
                     reload = False
                 if reload == True:
                     logging.info(f"Applying SierraBreezeEnhanced titlebar opacity")
                     with open(SBE_RC, 'w') as configfile:
-                        sberc.write(configfile,space_around_delimiters=False)
+                        conf_file.write(configfile,space_around_delimiters=False)
                     kwin_reload()
             except Exception as e:
                 logging.error(f"Error writing SierraBreezeEnhanced titlebar opacity:\n{e}")
+                
+        if os.path.exists(KLASSY_RC):
+            try:
+                conf_file.read(KLASSY_RC)
+                if 'Common' in conf_file:
+                    conf_file['Common']['ActiveTitlebarOpacity'] = str(int(opacity))
+                    conf_file['Common']['InactiveTitlebarOpacity'] = str(int(opacity))
+                    reload = True
+                else:
+                    reload = False
+                if reload == True:
+                    logging.info(f"Applying Klassy titlebar opacity")
+                    with open(KLASSY_RC, 'w') as configfile:
+                        conf_file.write(configfile,space_around_delimiters=False)
+                    kwin_reload()
+            except Exception as e:
+                logging.error(f"Error writing Klassy titlebar opacity:\n{e}")
 
 def dict_to_rgb(dark_scheme):
         out = {}


### PR DESCRIPTION
* rename sbe_titlebar_opacity to titlebar_opacity
* rename toolbar opacity and titlebar opacity flags to:
* --titlebar-opacity, -tio
* --toolbar-opacity,  -too