### PR TITLE
Add support for more palette types

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -105,7 +105,8 @@ class Configs():
             'custom_colors_list': [args.custom_colors_list, None, 3],
             'darker_window_list': [args.darker_window_list, None, 3],
             'use_startup_delay': [args.use_startup_delay, None, 0],
-            'startup_delay': [args.startup_delay, 0, 1]
+            'startup_delay': [args.startup_delay, 0, 1],
+            'palette_type':[args.palette_type, 0, 1]
         }
         options = defaults
         config = get_conf(globals.USER_CONFIG_PATH + globals.CONFIG_FILE)
@@ -153,6 +154,11 @@ class Configs():
             logging.warning(
                 'Value for startup_delay must be an positive integer, using default 0')
             options['startup_delay'] = 0
+
+        if options['palette_type'] < 0:
+            logging.warning(
+                'Value for palette_type must be an positive integer, using default 0')
+            options['palette_type'] = 0
 
         try:
             if options['custom_colors_list'] is not None:

--- a/src/kde-material-you-colors
+++ b/src/kde-material-you-colors
@@ -166,6 +166,12 @@ if __name__ == '__main__':
                         help='Add a startup delay (in seconds) before doing anything, useful for waiting for other utilities that may change themes on boot (default is 0), requires --use-startup-delay option',
                         default=None,
                         metavar='<integer>')
+
+    parser.add_argument('--palette-type','-pt',
+                        type=int,
+                        help='Palette type to use 0=Core (default) An intermediate concept between the key color for a UI theme, and a full color scheme. 1=Fidelity Tokens and palettes match source color. Primary Container is source color, adjusted to ensure contrast with surfaces. 2=Monochrome All colors are grayscale, no chroma. 3=Neutral Close to grayscale, a hint of chroma. 4=TonalSpot Pastel tokens, low chroma palettes (32). Default Material You theme at 2021 launch.',
+                        metavar='<integer>')
+
     # Get commandline arguments
     args = parser.parse_args()
     # Check for one shot arguments

--- a/src/sample_config.conf
+++ b/src/sample_config.conf
@@ -47,6 +47,16 @@ plugin = org.kde.image
 # Default is 0
 ncolor = 0
 
+# Palette type to use
+# Accepted values are:
+# 0:  Core (default), an intermediate concept between the key color for a UI theme, and a full color scheme.
+# 1:  Fidelity, tokens and palettes match source color. Primary Container is source color, adjusted to ensure contrast with surfaces
+# 2:  Monochrome, all colors are grayscale, no chroma.
+# 3:  Neutral, close to grayscale, a hint of chroma.
+# 4:  TonalSpot, pastel tokens, low chroma palettes (32). Default Material You theme at 2021 launch.
+# Default is 0
+palette_type = 0
+
 # Light scheme icons theme
 # Commented by default
 #iconslight = Papirus-Light

--- a/src/theme_selector.py
+++ b/src/theme_selector.py
@@ -28,6 +28,7 @@ def apply_themes(
         config_watcher.get_new_value()['ncolor'],
         config_watcher.get_new_value()['light_blend_multiplier'],
         config_watcher.get_new_value()['dark_blend_multiplier'],
+        config_watcher.get_new_value()['palette_type']
     ])
 
     # Get wallpaper type and data
@@ -72,7 +73,7 @@ def apply_themes(
         material_colors.set_value(
             m3_scheme_utils.get_color_schemes(
                 wallpaper_watcher.get_new_value(),
-                config_watcher.get_new_value()['ncolor'])
+                config_watcher.get_new_value()['ncolor'],palette_type=config_watcher.get_new_value()['palette_type'])
         )
         if material_colors.get_new_value() != None:
             # Genrate color schemes from MYou colors
@@ -275,7 +276,7 @@ def apply_themes(
                 if config_watcher.get_new_value()['toolbar_opacity'] != None:
                     material_colors.set_value(m3_scheme_utils.get_color_schemes(
                         wallpaper_watcher.get_new_value(),
-                        config_watcher.get_new_value()['ncolor']))
+                        config_watcher.get_new_value()['ncolor'],palette_type=config_watcher.get_new_value()['palette_type']))
                 if material_colors.get_new_value() != None:
                     # Genrate color schemes from MYou colors
                     schemes_watcher.set_value(
@@ -379,7 +380,7 @@ def apply_themes(
 
                 material_colors.set_value(m3_scheme_utils.get_color_schemes(
                     wallpaper_watcher.get_new_value(),
-                    config_watcher.get_new_value()['ncolor']))
+                    config_watcher.get_new_value()['ncolor'],palette_type=config_watcher.get_new_value()['palette_type']))
                 if material_colors.get_new_value() != None:
                     # Genrate color schemes from MYou colors
                     schemes_watcher.set_value(

--- a/src/utils/m3_scheme_utils.py
+++ b/src/utils/m3_scheme_utils.py
@@ -6,7 +6,9 @@ if globals.USER_HAS_COLR:
 from . import color_utils
 from . import math_utils
 from .extra_image_utils import sourceColorsFromImage
-from material_color_utilities_python.utils.theme_utils import *
+from .m3_theme_utils import *
+from .palettes.palettes import *
+from material_color_utilities_python.palettes.core_palette import *
 
 
 def dict_to_rgb(dark_scheme):
@@ -40,7 +42,7 @@ def get_custom_colors(custom_colors):
     return colors
 
 
-def get_material_you_colors(wallpaper_data, ncolor, source_type):
+def get_material_you_colors(wallpaper_data, ncolor, source_type,palette_type:int=0):
     """ Get material you colors from wallpaper or hex color using material-color-utility
 
     Args:
@@ -51,6 +53,35 @@ def get_material_you_colors(wallpaper_data, ncolor, source_type):
     Returns:
         str: string data from python-material-color-utilities
     """
+
+    palette_types = {
+        0:{
+            "name":"Core (default)",
+            "palette":CorePalette
+        },
+        1:{
+            "name":"Fidelity",
+            "palette":FidelityPalette
+        },
+        2:{
+            "name":"Monochrome",
+            "palette":MonochromePalette
+        },
+        3:{
+            "name":"Neutral",
+            "palette":NeutralPalette
+        },
+        4:{
+            "name":"Tonal Spot",
+            "palette":TonalSpotPalette
+        }
+        }
+
+    if palette_type > len(palette_types) - 1:
+        palette_type = 0
+    #print(palette_types)
+    logging.info(f"Using {palette_type}:{palette_types[palette_type]['name']} palette")
+    palette_type=palette_types[palette_type]['palette']
 
     try:
         seedColor = 0
@@ -76,7 +107,7 @@ def get_material_you_colors(wallpaper_data, ncolor, source_type):
         for i, color in enumerate(source_colors):
             best_colors.update({str(i): hexFromArgb(color)})
         # generate theme from seed color
-        theme = themeFromSourceColor(seed_color)
+        theme = themeFromSourceColor(source=seed_color,palette_type=palette_type)
 
         # Given a image, the alt color and hex color
         # return a selected color or a single color for hex code
@@ -93,7 +124,7 @@ def get_material_you_colors(wallpaper_data, ncolor, source_type):
             seedColor = hexFromArgb(source_colors[-1])
             seedNo = totalColors-1
         if seedColor != 0:
-            theme = themeFromSourceColor(argbFromHex(seedColor))
+            theme = themeFromSourceColor(argbFromHex(seedColor),palette_type=palette_type)
 
         dark_scheme = json.loads(theme['schemes']['dark'].toJSON())
         light_scheme = json.loads(theme['schemes']['light'].toJSON())
@@ -134,7 +165,7 @@ def get_material_you_colors(wallpaper_data, ncolor, source_type):
         return None
 
 
-def get_color_schemes(wallpaper, ncolor=None):
+def get_color_schemes(wallpaper, ncolor=None,palette_type:int=0):
     """ Display best colors, allow to select alternative color,
     and make and apply color schemes for dark and light mode
 
@@ -156,7 +187,7 @@ def get_color_schemes(wallpaper, ncolor=None):
                 if not os.path.isdir(wallpaper_data):
                     # get colors from material-color-utility
                     materialYouColors = get_material_you_colors(
-                        wallpaper_data, ncolor=ncolor, source_type=source_type)
+                        wallpaper_data, ncolor=ncolor, source_type=source_type,palette_type=palette_type)
                 else:
                     logging.error(
                         f'"{wallpaper_data}" is a directory, aborting')
@@ -165,7 +196,7 @@ def get_color_schemes(wallpaper, ncolor=None):
             source_type = "color"
             wallpaper_data = color_utils.color2hex(wallpaper_data)
             materialYouColors = get_material_you_colors(
-                wallpaper_data, ncolor=ncolor, source_type=source_type)
+                wallpaper_data, ncolor=ncolor, source_type=source_type,palette_type=palette_type)
 
         if materialYouColors != None:
             try:

--- a/src/utils/m3_theme_utils.py
+++ b/src/utils/m3_theme_utils.py
@@ -1,0 +1,79 @@
+from material_color_utilities_python.blend.blend import *
+from material_color_utilities_python.palettes.core_palette import *
+from material_color_utilities_python.utils.image_utils import *
+from material_color_utilities_python.utils.string_utils import *
+from .palettes.palettes import *
+from .schemes.m3_schemes import *
+
+# /**
+#  * Generate custom color group from source and target color
+#  *
+#  * @param source Source color
+#  * @param color Custom color
+#  * @return Custom color group
+#  *
+#  * @link https://m3.material.io/styles/color/the-color-system/color-roles
+#  */
+# NOTE: Changes made to output format to be Dictionary
+def customColor(source, color, palette_type):
+    value = color["value"]
+    from_v = value
+    to = source
+    if (color["blend"]):
+        value = Blend.harmonize(from_v, to)
+    palette = palette_type.of(value)
+    tones = palette.a1
+    return {
+        "color": color,
+        "value": value,
+        "light": {
+            "color": tones.tone(40),
+            "onColor": tones.tone(100),
+            "colorContainer": tones.tone(90),
+            "onColorContainer": tones.tone(10),
+        },
+        "dark": {
+            "color": tones.tone(80),
+            "onColor": tones.tone(20),
+            "colorContainer": tones.tone(30),
+            "onColorContainer": tones.tone(90),
+        },
+    }
+
+# /**
+#  * Generate a theme from a source color
+#  *
+#  * @param source Source color
+#  * @param customColors Array of custom colors
+#  * @return Theme object
+#  */
+# NOTE: Changes made to output format to be Dictionary
+def themeFromSourceColor(source, palette_type, customColors:list=[]):
+    palette = palette_type.of(source)
+    return {
+        "source": source,
+        "schemes": {
+            "light": Scheme.light(source,palette_type),
+            "dark": Scheme.dark(source,palette_type),
+        },
+        "palettes": {
+            "primary": palette.a1,
+            "secondary": palette.a2,
+            "tertiary": palette.a3,
+            "neutral": palette.n1,
+            "neutralVariant": palette.n2,
+            "error": palette.error,
+        },
+        "customColors": [customColor(source, c, palette_type) for c in customColors]
+    }
+
+# /**
+#  * Generate a theme from an image source
+#  *
+#  * @param image Image element
+#  * @param customColors Array of custom colors
+#  * @return Theme object
+#  */
+def themeFromImage(image, palette_type, customColors = []):
+    source = sourceColorFromImage(image)
+    return themeFromSourceColor(source, palette_type, customColors)

--- a/src/utils/palettes/palettes.py
+++ b/src/utils/palettes/palettes.py
@@ -1,0 +1,94 @@
+
+from material_color_utilities_python.hct.hct import *
+from material_color_utilities_python.palettes.tonal_palette import *
+
+# /**
+#  * A scheme that places the source color in `Scheme.primaryContainer`.
+#  *
+#  * Primary Container is the source color, adjusted for color relativity.
+#  * It maintains constant appearance in light mode and dark mode.
+#  * This adds ~5 tone in light mode, and subtracts ~5 tone in dark mode.
+#  * Tertiary Container is the complement to the source color, using
+#  * `TemperatureCache`. It also maintains constant appearance.
+#  */
+class FidelityPalette:
+    def __init__(self, argb):
+        hct = Hct.fromInt(argb)
+        chroma = hct.chroma
+        hue = hct.hue
+        self.a1 = TonalPalette.fromHueAndChroma(hue, chroma)
+        self.a2 = TonalPalette.fromHueAndChroma(hue, max(chroma - 32.0, chroma * 0.5))
+        self.a3 = TonalPalette.fromHueAndChroma(hue, 16.0) # TODO add DislikeAnalyzer
+        self.n1 = TonalPalette.fromHueAndChroma(hue, chroma / 8.0)
+        self.n2 = TonalPalette.fromHueAndChroma(hue, chroma / 8.0 + 4.0)
+        self.error = TonalPalette.fromHueAndChroma(25, 84)
+
+    # /**
+    #  * @param argb ARGB representation of a color
+    #  */
+    @staticmethod
+    def of(argb):
+        return FidelityPalette(argb)
+
+# /** A Color Palette that is grayscale. */
+class MonochromePalette:
+    def __init__(self, argb):
+        hct = Hct.fromInt(argb)
+        hue = hct.hue
+        self.a1 = TonalPalette.fromHueAndChroma(hue, 0.0)
+        self.a2 = TonalPalette.fromHueAndChroma(hue, 0.0)
+        self.a3 = TonalPalette.fromHueAndChroma(hue, 0.0)
+        self.n1 = TonalPalette.fromHueAndChroma(hue, 0.0)
+        self.n2 = TonalPalette.fromHueAndChroma(hue, 0.0)
+        self.error = TonalPalette.fromHueAndChroma(25, 84)
+
+    # /**
+    #  * @param argb ARGB representation of a color
+    #  */
+    @staticmethod
+    def of(argb):
+        return MonochromePalette(argb);
+
+# /** A Color Palette that is near grayscale. */
+class NeutralPalette:
+    def __init__(self, argb):
+        hct = Hct.fromInt(argb)
+        hue = hct.hue
+        self.a1 = TonalPalette.fromHueAndChroma(hue, 12.0)
+        self.a2 = TonalPalette.fromHueAndChroma(hue, 8.0)
+        self.a3 = TonalPalette.fromHueAndChroma(hue, 16.0)
+        self.n1 = TonalPalette.fromHueAndChroma(hue, 2.0)
+        self.n2 = TonalPalette.fromHueAndChroma(hue, 2.0)
+        self.error = TonalPalette.fromHueAndChroma(25, 84)
+
+    # /**
+    #  * @param argb ARGB representation of a color
+    #  */
+    @staticmethod
+    def of(argb):
+        return NeutralPalette(argb)
+
+
+# /**
+#  * A Dynamic Color theme with low to medium colorfulness and a Tertiary
+#  * TonalPalette with a hue related to the source color.
+#  *
+#  * The default Material You theme on Android 12 and 13.
+#  */
+class TonalSpotPalette:
+    def __init__(self, argb):
+        hct = Hct.fromInt(argb)
+        hue = hct.hue
+        self.a1 = TonalPalette.fromHueAndChroma(hue, 40.0)
+        self.a2 = TonalPalette.fromHueAndChroma(hue, 16.0)
+        self.a3 = TonalPalette.fromHueAndChroma(sanitizeDegreesDouble(hue + 60.0), 24.0) # TODO add DislikeAnalyzer
+        self.n1 = TonalPalette.fromHueAndChroma(hue, 6.0)
+        self.n2 = TonalPalette.fromHueAndChroma(hue, 8.0)
+        self.error = TonalPalette.fromHueAndChroma(25, 84)
+
+    # /**
+    #  * @param argb ARGB representation of a color
+    #  */
+    @staticmethod
+    def of(argb):
+        return TonalSpotPalette(argb)


### PR DESCRIPTION
In order:
- Core (default)
- Fidelity
- Monochrome
- Neutral
- Tonal Spot
![palette-comp](https://github.com/luisbocanegra/kde-material-you-colors/assets/15076387/acae7062-c6b5-4e98-82d5-59a71379ef7b)
