### PR TITLE
Port from qdbus to gdbus command

### DIFF
--- a/src/kde_material_you_colors/apply_themes.py
+++ b/src/kde_material_you_colors/apply_themes.py
@@ -16,13 +16,6 @@ from kde_material_you_colors.utils import (
 
 def apply(config: Configs, wallpaper: WallpaperReader, dark_light):
     needs_kwin_reload = False
-    qdbus_executable = config.read("qdbus_executable")
-    if qdbus_executable is None:
-        qdbus_executable = "qdbus6"
-    if utils.find_executable(qdbus_executable) is None:
-        logging.error(
-            f"QDbus executable '{qdbus_executable}' wasn't found, there will be errors. Please set the correct one in the configuration"
-        )
 
     material_colors = m3_scheme_utils.get_color_schemes(
         wallpaper,
@@ -80,7 +73,7 @@ def apply(config: Configs, wallpaper: WallpaperReader, dark_light):
         dark_light=dark_light,
     )
     if config.read("disable_konsole") is not True:
-        konsole_utils.apply_color_scheme(qdbus_executable)
+        konsole_utils.apply_color_scheme()
     if config.read("darker_window_list"):
         titlebar_utils.kwin_rule_darker_titlebar(
             (
@@ -99,7 +92,7 @@ def apply(config: Configs, wallpaper: WallpaperReader, dark_light):
             dark_light=dark_light,
         )
     if needs_kwin_reload is True:
-        kwin_utils.reload(qdbus_executable)
+        kwin_utils.reload()
     pywal_utils.print_color_palette(
         light=config.read("light"),
         pywal_light=config.read("pywal_light"),

--- a/src/kde_material_you_colors/config.py
+++ b/src/kde_material_you_colors/config.py
@@ -119,6 +119,11 @@ class Configs:
                 f"Value for main_loop_delay ({options['main_loop_delay']}) should be smaller than screenshot_delay ({options['screenshot_delay']}), will be set to {options['screenshot_delay']}"
             )
 
+        if options["qdbus_executable"] is not None:
+            logging.warning(
+                "--qdbus-executable (qdbus_executable in config) is deprecated as of version 1.10.0 and will be removed in a later version"
+            )
+
         self._options = options
 
     @property

--- a/src/kde_material_you_colors/data/sample_config.conf
+++ b/src/kde_material_you_colors/data/sample_config.conf
@@ -194,4 +194,5 @@ tone_multiplier = 1
 # QDbus executable
 # Name or location of the QDbus executable e.g qdbus6, qdbus-qt6...
 # Default is qdbus6
-#qdbus_executable = qdbus6
+# Deprecated, no longer needed as of version 1.10.0. Switched to gdbus command from glib2
+# qdbus_executable = qdbus6

--- a/src/kde_material_you_colors/main.py
+++ b/src/kde_material_you_colors/main.py
@@ -337,7 +337,7 @@ def main():
     parser.add_argument(
         "--qdbus-executable",
         type=str,
-        help="Name or location of the QDbus executable e.g qdbus6, qdbus-qt6... (default is qdbus6)",
+        help="(Deprecated as of version 1.10.0) Name or location of the QDbus executable e.g qdbus6, qdbus-qt6... (default is qdbus6)",
         default=None,
         metavar="<string>",
     )

--- a/src/kde_material_you_colors/utils/dbus_utils.py
+++ b/src/kde_material_you_colors/utils/dbus_utils.py
@@ -1,0 +1,53 @@
+from xml.etree import ElementTree
+import dbus
+
+
+def list_paths(
+    bus: dbus.Bus,
+    service: str,
+    search_path: str = "/",
+    current_path: str = "",
+    paths=None,
+):
+    """List the paths from a dbus service
+
+    Args:
+        bus (dbus.Bus): Bus
+        service (str): the service to connect to (e.g., org.freedesktop.DBus)
+        search_path (str, optional): The path to search in. Defaults to "/".
+        current_path (str, optional): Used in iterations. Defaults to "".
+        paths (list, optional): Current found paths. Defaults to None.
+
+    Returns:
+        list: Found paths
+    """
+    if paths is None:
+        paths = []
+    if not search_path.startswith("/"):
+        search_path = "/" + search_path
+    if current_path == "":
+        current_path = search_path
+    if search_path != current_path and current_path not in paths:
+        paths.append(current_path)
+    obj = bus.get_object(service, current_path)
+    # adapted from https://unix.stackexchange.com/a/203678
+    iface = dbus.Interface(obj, "org.freedesktop.DBus.Introspectable")
+    xml_string = iface.Introspect()
+    for child in ElementTree.fromstring(xml_string):
+        if child.tag == "node":
+            if current_path == "/":
+                current_path = ""
+            new_path = "/".join((current_path, child.attrib["name"]))
+            list_paths(bus, service, search_path, new_path, paths)
+    return paths
+
+
+if __name__ == "__main__":
+
+    session_bus = dbus.SessionBus()
+    print(
+        list_paths(
+            session_bus, "org.kde.konsole-311544", "/Sessions", "", ["/Sessions/1"]
+        )
+    )
+    print(list_paths(session_bus, "org.kde.plasmashell"))

--- a/src/kde_material_you_colors/utils/wallpaper_utils.py
+++ b/src/kde_material_you_colors/utils/wallpaper_utils.py
@@ -23,7 +23,6 @@ class WallpaperReader:
         self._file = config.read("file")
         self._color = config.read("color")
         self._light = config.read("light")
-        self._qdbus_executable = config.read("qdbus_executable") or "qdbus6"
         self._plugin = None
         self._type = None
         self._source = None
@@ -98,9 +97,7 @@ class WallpaperReader:
             self._error = "Screenshot helper is not installed. Use another wallpaper plugin or install the helper"
             return
         try:
-            screenshot_taken = get_desktop_screenshot(
-                self._monitor, self._qdbus_executable
-            )
+            screenshot_taken = get_desktop_screenshot(self._monitor)
         except subprocess.CalledProcessError as e:
             logging.exception(e)
             self._error = f"cmd {e.cmd}\nError: {e.stderr}"
@@ -205,10 +202,10 @@ class WallpaperReader:
         return self._type == "screenshot"
 
 
-def get_desktop_screenshot(screen=0, qdbus_executable="qdbus6"):
+def get_desktop_screenshot(screen=0):
     # take screenshot of desktop
     try:
-        window_handle = kwin_utils.get_desktop_window_id(screen, qdbus_executable)
+        window_handle = kwin_utils.get_desktop_window_id(screen)
     except Exception as e:
         logging.exception(e)
         raise

--- a/src/plasmoid/package/contents/ui/FullRepresentation.qml
+++ b/src/plasmoid/package/contents/ui/FullRepresentation.qml
@@ -548,7 +548,6 @@ ColumnLayout {
                                     property int scheme_variant: 5; \
                                     property real chroma_multiplier: 1.0; \
                                     property real tone_multiplier: 1.0; \
-                                    property string qdbus_executable; \
                                 }';
 
                             settings = Qt.createQmlObject(settingsString, mainLayout, "settingsObject");
@@ -1796,48 +1795,6 @@ ColumnLayout {
                                 opacity: dividerOpacity
                             }
 
-                            RowLayout {
-                                Layout.alignment: Qt.AlignHCenter
-                                PlasmaExtras.Heading {
-                                    level: 1
-                                    text: "QDbus executable"
-                                }
-                                PlasmaComponents3.ToolButton {
-                                    id: qdbusInfoBtn
-                                    icon.name: "help-hint"
-                                    opacity: 0.7
-                                    hoverEnabled: true
-                                    onClicked: qdbusInfoPopup.open()
-
-                                    PlasmaComponents3.ToolTip {
-                                        id: qdbusInfoPopup
-                                        x: qdbusInfoBtn.width / 2
-                                        y: qdbusInfoBtn.height
-                                        text: "Name or location of the QDbus executable e.g qdbus6, qdbus-qt6... (default is qdbus6)"
-                                    }
-                                }
-                            }
-
-                            RowLayout {
-                                PlasmaComponents3.Label {
-                                    text: "Executable"
-                                }
-                                PlasmaComponents3.TextField {
-                                    placeholderText: qsTr("e.g qdbus6, qdbus-qt6... (default is qdbus6)")
-                                    Layout.fillWidth: true
-                                    text: settings.qdbus_executable
-                                    onAccepted: {
-                                        settings.qdbus_executable = text
-                                    }
-                                }
-                                PlasmaComponents3.Button {
-                                    icon.name: "document-open"
-                                    onClicked: {
-                                        fileDialogQdbusExec.open()
-                                    }
-                                }
-                            }
-
                             Rectangle {
                                 Layout.preferredWidth: mainLayout.width
                                 height: 1
@@ -2076,13 +2033,6 @@ ColumnLayout {
                                 id: fileDialogHookExec
                                 onAccepted: {
                                     mainLayout.settings.on_change_hook = fileDialogHookExec.fileUrl.toString().substring(7)
-                                }
-                            }
-
-                            FileDialog {
-                                id: fileDialogQdbusExec
-                                onAccepted: {
-                                    mainLayout.settings.qdbus_executable = fileDialogQdbusExec.fileUrl.toString().substring(7)
                                 }
                             }
 


### PR DESCRIPTION
Porting away from [qdbus](https://github.com/qt/qttools/tree/dev/src/qdbus) command to plain [dbus-python](http://www.freedesktop.org/wiki/Software/DBusBindings#python) + [gdbus](https://github.com/GNOME/glib/blob/main/gio/gdbus-tool.c) command (when dbus-python doesn't work).

Unlike `qdbus`, `gdbus` has a standard name/location and _should_ always be on the $PATH so it will fix the problem of having to manually configure it

Removes qdbus executable option

Closes: https://github.com/luisbocanegra/kde-material-you-colors/issues/224