### PR TITLE
Manual color fetch feature and fixes on dynamic wallpaper compatibility

### DIFF
--- a/src/kde_material_you_colors/config.py
+++ b/src/kde_material_you_colors/config.py
@@ -176,6 +176,8 @@ class Configs:
             "chroma_multiplier": [args.chroma_multiplier, 1, 2],
             "tone_multiplier": [args.tone_multiplier, 1, 2],
             "qdbus_executable": [args.qdbus_executable, None, 3],
+            "manual_fetch": [args.manual_fetch, False, 0],
+            "fetch_colors": [None, False, 0],
         }
 
     def parse_conf(self):

--- a/src/kde_material_you_colors/data/sample_config.conf
+++ b/src/kde_material_you_colors/data/sample_config.conf
@@ -147,6 +147,7 @@ ncolor = 0
 # of detections for those cases to save power.
 # NOTE:
 # Should be bigger than main_loop_delay (will take main_loop_delay otherwise)
+# Ignored if manual color fetch is enabled
 # Default is 900 seconds (15 minutes)
 # Commented by default
 #screenshot_delay = 900
@@ -196,3 +197,9 @@ tone_multiplier = 1
 # Default is qdbus6
 # Deprecated, no longer needed as of version 1.10.0. Switched to gdbus command from glib2
 # qdbus_executable = qdbus6
+
+# Manual fetch
+# Disables the automatic color fetching and
+# scheduled screenshot take in screenshot mode
+# Default is False
+manual_fetch = False

--- a/src/plasmoid/package/contents/ui/FullRepresentation.qml
+++ b/src/plasmoid/package/contents/ui/FullRepresentation.qml
@@ -59,7 +59,11 @@ ColumnLayout {
 
     property bool pauseMode: false
 
+    property bool manual_fetch: false
+
+
     signal savePauseMode()
+
 
     property Item parentMain
 
@@ -82,7 +86,6 @@ ColumnLayout {
             parentMain.pauseModeMain = fullRepresentation.pauseMode
         }
     }
-
 
     // Get a list of installed icon themes as id,name
     // - discard hidden themes
@@ -331,7 +334,6 @@ ColumnLayout {
                     level: 1
                     text: Plasmoid.metaData.name
                 }
-
                 PlasmaComponents3.ToolButton {
                     display: PlasmaComponents3.AbstractButton.IconOnly
                     visible: !onDesktop
@@ -346,7 +348,6 @@ ColumnLayout {
                         text: parent.text
                     }
                 }
-
                 PlasmaComponents3.ToolButton {
                     display: PlasmaComponents3.AbstractButton.IconOnly
                     checkable: false
@@ -452,14 +453,12 @@ ColumnLayout {
                                 }
                             }
                         }
-
                         Connections {
                             target: fullRepresentation
                             function onSavePauseMode() {
                                 settings.pause_mode = fullRepresentation.pauseMode
                             }
                         }
-
                         onMaterialYouDataChanged: {
                             if (materialYouData!=null && materialYouDataString!=null) {
                                 if (JSON.stringify(materialYouData) !== materialYouDataString) {
@@ -544,6 +543,8 @@ ColumnLayout {
                                     property int screenshot_delay: 900; \
                                     property bool once_after_change: false; \
                                     property bool pause_mode: false; \
+                                    property bool manual_fetch: false; \
+                                    property bool fetch_colors: false; \
                                     property bool screenshot_only_mode: false; \
                                     property int scheme_variant: 5; \
                                     property real chroma_multiplier: 1.0; \
@@ -812,17 +813,37 @@ ColumnLayout {
                             // Color selection
                             RowLayout {
                                 Layout.preferredWidth: mainLayout.width
-
-                                PlasmaComponents3.Label {
-                                    text: "Select color"
-                                    id:selectColorLabel
-                                    Layout.fillWidth: settings.color!==""
+                                RowLayout {
+                                    id: selectColorLayout
+                                    PlasmaComponents3.Label {
+                                        text: "Select color"
+                                        id:selectColorLabel
+                                    }
+                                    // Button to manually fetch the colors on screen //
+                                    Timer {
+                                        id: fetchTimer
+                                        interval: settings.main_loop_delay * 1000; running: false; repeat: false;
+                                        onTriggered: settings.fetch_colors = false
+                                    }
+                                    RowLayout {
+                                        PlasmaComponents3.Button {
+                                            text: "Fetch colors"
+                                            icon.name: 'refreshstructure'
+                                            onClicked: {
+                                                settings.fetch_colors = true
+                                                fetchTimer.start()
+                                            }
+                                            PlasmaComponents3.ToolTip {
+                                                text: "Manually fetch the colors on the current wallpaper"
+                                            }
+                                        }
+                                    }
                                 }
 
                                 // Single color picker when color is not empty
                                 Components.CustomColorButton { // Components.Custom
                                     id: colorButton
-                                    Layout.alignment: Qt.AlignHCenter
+                                    Layout.alignment : Qt.AlignRight
                                     visible: settings.color!==""
                                     showAlphaChannel: false
                                     dialogTitle: "Choose source color"
@@ -840,7 +861,7 @@ ColumnLayout {
                                 GridLayout { //PlasmaComponents3.ScrollView
                                     property var gridSpacing: Kirigami.Units.mediumSpacing
                                     visible: settings.color===""
-                                    columns: Math.floor((mainLayout.width - selectColorLabel.width) / (
+                                    columns: Math.floor((mainLayout.width - selectColorLayout.width) / (
                                         controlHeight * .75 + gridSpacing))
                                     rowSpacing: gridSpacing
                                     columnSpacing: gridSpacing
@@ -1919,6 +1940,36 @@ ColumnLayout {
                                     }
                                 }
                             }
+                            RowLayout {
+                                PlasmaComponents3.Label {
+                                    text: "Manual color fetch only"
+                                    Layout.alignment: Qt.AlignLeft
+                                }
+
+                                PlasmaComponents3.CheckBox {
+                                    checked: settings.manual_fetch
+
+                                    onCheckedChanged: {
+                                        settings.manual_fetch = checked
+                                        fullRepresentation.manual_fetch = checked
+                                    }
+                                }
+
+                                PlasmaComponents3.ToolButton {
+                                    icon.name: "help-contents"
+
+                                    hoverEnabled: true
+                                    onClicked: manualFetchPopup.open()
+
+                                    PlasmaComponents3.ToolTip {
+                                        id: manualFetchPopup
+                                        x: parent.width / 2
+                                        y: parent.height
+                                        text: "The backend won't fetch the colors in the delay times, instead, it will fetch only when the 'Fetch colors' button is pressed by the user. Useful when using dynamic wallpapers."
+                                    }
+                                }
+                            }
+
 
                             RowLayout {
                                 PlasmaComponents3.Label {


### PR DESCRIPTION
Added 2 new features, a "Fetch colors" button in the widget, which fetches colors from current wallpaper, and the manual fetch option, which basically freezes the wallpaper detection protocol in order to always need to press the fetch button to get new colors. These new options are useful if the user is using a dynamic wallpaper or video, and also partially fixes the color select bug addressed at Issue #229 .
Edit: Add images
![Screenshot 1](https://github.com/user-attachments/assets/9c862036-6dd3-4773-ac26-91a4fec041dd)
![Screenshot 2](https://github.com/user-attachments/assets/7ef8c937-8c49-4745-9df8-9e226af2cf34)
