### PR TITLE
Fix README.md to show correct manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Automatically generate light/dark color themes for KDE (and pywal if installed) 
 
     ```sh
     git clone https://github.com/luisbocanegra/kde-material-you-colors
+    cd kde-material-you-colors
     ./install-screenshot-helper.sh
     ```
 
@@ -103,6 +104,7 @@ Automatically generate light/dark color themes for KDE (and pywal if installed) 
 
     ```sh
     git clone https://github.com/luisbocanegra/kde-material-you-colors -b plasma5
+    cd kde-material-you-colors
     ./install-screenshot-helper.sh
     ```
 


### PR DESCRIPTION
I wanted to install it via manual installation. I copied and pasted instructions into terminal. However I noticed only after run that commands are not right. There is no `cd` after `git clone`. The pull request is here to fix it!